### PR TITLE
fix: Skip tag release step on main branch push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
 
 
       - name: Add to tag
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           current_tag=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
           echo "Current tag is $current_tag"


### PR DESCRIPTION
- Add condition to 'Add to tag' step: only run on tag push
- Prevents workflow failure when merging PRs to main
- Build step still runs on main push to validate actions

The workflow was failing on every main branch push because it tried to execute tag-specific operations without an actual tag.