### PR TITLE
Fix /tmp/ path restriction in Claude Code review

### DIFF
--- a/claude-django-review/action.yml
+++ b/claude-django-review/action.yml
@@ -155,6 +155,8 @@ runs:
           - Provide concrete code examples where helpful
           - For query issues, trace the complete execution path with line numbers
 
+          IMPORTANT: Never write files to /tmp/ or any directory outside the repository root. All file operations must use relative paths in the current working directory.
+
           Save your ${{ inputs.review_language }} review to a file named '.claude-code-review-initial.md' using Write tool. Do NOT post to PR yet.
 
         claude_args: '--model ${{ inputs.model }} --allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Write,Read,Glob,Grep"'
@@ -188,6 +190,8 @@ runs:
              - Specific file:line references provided
              - Concrete code examples given
              - Clear decision (APPROVE/COMMENT/REQUEST_CHANGES)
+
+          IMPORTANT: Never write files to /tmp/ or any directory outside the repository root. All file operations must use relative paths in the current working directory.
 
           **Your Actions:**
           - If review is incomplete or missed critical issues:


### PR DESCRIPTION
## Summary
- Claude Code sandbox가 `/tmp/` 경로 쓰기를 차단하여 AI Review 실행 시 에러 발생
- 두 프롬프트에 `/tmp/` 사용 금지 + 상대 경로 사용 지시 추가

## Error
```
Output redirection to '/tmp/pr3_diff.txt' was blocked.
For security, Claude Code may only write to files in the allowed working directories
```

## Root Cause
Claude Code AI가 `gh pr diff` 출력을 `/tmp/pr3_diff.txt`로 리다이렉트하려다 sandbox 정책에 차단됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)