### PR TITLE
chore: add reusable workflow for sentry-autofix

### DIFF
--- a/.github/workflows/notify-slack-pr-merged.yml
+++ b/.github/workflows/notify-slack-pr-merged.yml
@@ -1,0 +1,44 @@
+name: Notify Slack on PR Merged
+
+on:
+  workflow_call:
+    secrets:
+      slack_bot_token:
+        required: true
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Find Slack TS from PR comments
+        id: find_slack
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMENT=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json comments \
+            --jq '.comments[].body | select(startswith("<!-- slack:"))' | head -1)
+
+          if [ -n "$COMMENT" ]; then
+            CHANNEL=$(echo "$COMMENT" | sed 's/<!-- slack:\([^:]*\):\(.*\) -->/\1/')
+            TS=$(echo "$COMMENT" | sed 's/<!-- slack:\([^:]*\):\(.*\) -->/\2/')
+            echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+            echo "ts=$TS" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add check reaction to Slack message
+        if: steps.find_slack.outputs.ts != ''
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.slack_bot_token }}
+        run: |
+          curl -s -X POST "https://slack.com/api/reactions.add" \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"channel\": \"${{ steps.find_slack.outputs.channel }}\",
+              \"timestamp\": \"${{ steps.find_slack.outputs.ts }}\",
+              \"name\": \"white_check_mark\"
+            }"

--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -1,0 +1,70 @@
+name: Sentry Autofix
+
+on:
+  workflow_call:
+    inputs:
+      new_relic_account_id:
+        required: true
+        type: string
+      slack_channel_id:
+        required: false
+        type: string
+        default: ''
+      model:
+        required: false
+        type: string
+        default: 'claude-opus-4-6'
+      sentry_issue_id:
+        required: true
+        type: string
+      sentry_url:
+        required: true
+        type: string
+      error_title:
+        required: true
+        type: string
+      error_culprit:
+        required: false
+        type: string
+        default: ''
+    secrets:
+      anthropic_api_key:
+        required: true
+      sentry_api_token:
+        required: true
+      new_relic_api_key:
+        required: true
+      linear_api_key:
+        required: true
+      slack_bot_token:
+        required: false
+
+concurrency:
+  group: sentry-autofix-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: drtail/actions/sentry-autofix@main
+        with:
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          sentry_api_token: ${{ secrets.sentry_api_token }}
+          new_relic_api_key: ${{ secrets.new_relic_api_key }}
+          new_relic_account_id: ${{ inputs.new_relic_account_id }}
+          linear_api_key: ${{ secrets.linear_api_key }}
+          slack_bot_token: ${{ secrets.slack_bot_token }}
+          slack_channel_id: ${{ inputs.slack_channel_id }}
+          model: ${{ inputs.model }}
+          sentry_issue_id: ${{ inputs.sentry_issue_id }}
+          sentry_url: ${{ inputs.sentry_url }}
+          error_title: ${{ inputs.error_title }}
+          error_culprit: ${{ inputs.error_culprit }}

--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -54,7 +54,43 @@ jobs:
       id-token: write
 
     steps:
+      - name: Check hourly rate limit
+        id: rate_limit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SLACK_BOT_TOKEN: ${{ secrets.slack_bot_token }}
+          SLACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
+        run: |
+          CUTOFF=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)
+
+          RECENT_COUNT=$(gh run list \
+            --repo ${{ github.repository }} \
+            --workflow "Sentry Autofix" \
+            --limit 20 \
+            --json createdAt \
+            --jq "[.[] | select(.createdAt > \"$CUTOFF\")] | length")
+
+          echo "Autofix runs in the last hour: $RECENT_COUNT"
+          echo "recent_count=$RECENT_COUNT" >> $GITHUB_OUTPUT
+
+          if [ "$RECENT_COUNT" -ge 5 ]; then
+            echo "rate_limited=true" >> $GITHUB_OUTPUT
+            if [ -n "$SLACK_BOT_TOKEN" ] && [ -n "$SLACK_CHANNEL_ID" ]; then
+              curl -s -X POST "https://slack.com/api/chat.postMessage" \
+                -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "{
+                  \"channel\": \"$SLACK_CHANNEL_ID\",
+                  \"text\": \"⚠️ [${{ github.repository }}] Sentry Autofix rate limit 초과 (${RECENT_COUNT}회/시간). 인프라 이슈 가능성이 있습니다. 수동 확인이 필요합니다.\n Sentry: ${{ inputs.sentry_url }}\"
+                }"
+            fi
+          else
+            echo "rate_limited=false" >> $GITHUB_OUTPUT
+          fi
+
       - uses: drtail/actions/sentry-autofix@main
+        if: steps.rate_limit.outputs.rate_limited == 'false'
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           sentry_api_token: ${{ secrets.sentry_api_token }}

--- a/sentry-autofix/action.yml
+++ b/sentry-autofix/action.yml
@@ -135,18 +135,28 @@ runs:
         GH_TOKEN: ${{ github.token }}
       run: |
         # Check for PR first, then GitHub Issue
-        PR_URL=$(gh pr list --repo ${{ github.repository }} --state open --json url,title --jq '.[0].url // empty')
-        PR_TITLE=$(gh pr list --repo ${{ github.repository }} --state open --json url,title --jq '.[0].title // empty')
+        PR_INFO=$(gh pr list --repo ${{ github.repository }} --state open --json number,url,title --jq '.[0] // empty')
+        PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
+        PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty')
+        PR_TITLE=$(echo "$PR_INFO" | jq -r '.title // empty')
 
         if [ -n "$PR_URL" ]; then
-          curl -s -X POST "https://slack.com/api/chat.postMessage" \
+          RESPONSE=$(curl -s -X POST "https://slack.com/api/chat.postMessage" \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{
               \"channel\": \"$SLACK_CHANNEL_ID\",
               \"text\": \"🔧 [${{ github.event.repository.name }}] AI Autofix PR이 생성되었습니다.\n<$PR_URL|$PR_TITLE>\",
               \"unfurl_links\": false
-            }"
+            }")
+
+          SLACK_TS=$(echo "$RESPONSE" | jq -r '.ts // empty')
+          SLACK_CHANNEL=$(echo "$RESPONSE" | jq -r '.channel // empty')
+
+          if [ -n "$SLACK_TS" ] && [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} \
+              --body "<!-- slack:${SLACK_CHANNEL}:${SLACK_TS} -->"
+          fi
           exit 0
         fi
 


### PR DESCRIPTION
## Summary
- `sentry-autofix/action.yml`: Slack 메시지 전송 후 `ts`를 받아 PR comment에 hidden marker로 저장 (`<!-- slack:CHANNEL:TS -->`)
- `.github/workflows/sentry-autofix.yml`: reusable workflow 추가 — 기존 composite action 호출 + concurrency 중앙 관리
- `.github/workflows/notify-slack-pr-merged.yml`: reusable workflow 추가 — PR merge 시 marker에서 `ts` 추출 → Slack `:white_check_mark:` reaction 추가

## 동작 흐름
```
Sentry alert → autofix 실행 → PR 생성
→ Slack 메시지 전송 (ts 캡처)
→ PR comment에 <!-- slack:CHANNEL:TS --> 저장

PR merge →
→ notify-slack-pr-merged workflow 트리거
→ PR comment에서 ts 추출
→ reactions.add :white_check_mark:
```

## 머지 순서
**이 PR을 먼저 머지한 후** drtail-server2, mochii-server PR을 머지해야 합니다.