### PR TITLE
fix: add actions:read permission and graceful fallback for rate limit check

### DIFF
--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -52,6 +52,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
 
     steps:
       - name: Check hourly rate limit
@@ -69,7 +70,8 @@ jobs:
             --workflow "Sentry Autofix" \
             --limit 20 \
             --json createdAt \
-            --jq "[.[] | select(.createdAt > \"$CUTOFF\")] | length")
+            --jq "[.[] | select(.createdAt > \"$CUTOFF\")] | length" 2>/dev/null || echo "0")
+          RECENT_COUNT=${RECENT_COUNT:-0}
 
           echo "Autofix runs in the last hour: $RECENT_COUNT"
           echo "recent_count=$RECENT_COUNT" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
E2E 테스트에서 `gh run list` 실패로 rate limit step이 exit code 1 발생하는 버그 수정.

- `permissions`에 `actions: read` 추가 — `gh run list` 실행 권한
- `gh run list` 실패 시 기본값 `0`으로 처리 — 권한 이슈 등 예외 상황에서 autofix가 계속 실행되도록