### PR TITLE
[DRT-4860] Add extra_labels input for sentry-autofix action

### DIFF
--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: ''
+      extra_labels:
+        required: false
+        type: string
+        default: ''
     secrets:
       anthropic_api_key:
         required: true
@@ -106,3 +110,4 @@ jobs:
           sentry_url: ${{ inputs.sentry_url }}
           error_title: ${{ inputs.error_title }}
           error_culprit: ${{ inputs.error_culprit }}
+          extra_labels: ${{ inputs.extra_labels }}

--- a/sentry-autofix/action.yml
+++ b/sentry-autofix/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: 'Error culprit from Sentry'
     required: false
     default: ''
+  extra_labels:
+    description: 'Additional labels to add to the PR (comma-separated)'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -86,7 +90,7 @@ runs:
               - Title: "[DRT-<number>] Fix: <short description>"
               - Body following .github/pull_request_template.md, include Sentry URL in References
               - Checklist must include: "머지 후 Sentry 이슈 resolve"
-              - Label: 🤖 AI Review
+              - Labels: 🤖 AI Review${{ inputs.extra_labels != '' && format(', {0}', inputs.extra_labels) || '' }}
 
           Important:
           - Follow the project conventions in CLAUDE.md


### PR DESCRIPTION
## Summary
- sentry-autofix action에 `extra_labels` input 추가
- reusable workflow에서 composite action으로 `extra_labels` 전달
- 각 레포에서 sentry autofix PR에 커스텀 라벨을 붙일 수 있도록 지원

## Context
- mochii-server에서 `🔧 Sentry Autofix` 라벨을 sentry autofix PR에 자동 부여하기 위한 변경
- 관련 PR: https://github.com/drtail/mochii-server/pull/177