### PR TITLE
sentry-autofix: slack_mention_user_id 입력 추가

### DIFF
--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: ''
+      slack_mention_user_id:
+        required: false
+        type: string
+        default: ''
       model:
         required: false
         type: string
@@ -88,7 +92,7 @@ jobs:
                 -H "Content-Type: application/json" \
                 -d "{
                   \"channel\": \"$SLACK_CHANNEL_ID\",
-                  \"text\": \"⚠️ [${{ github.repository }}] Sentry Autofix rate limit 초과 (${RECENT_COUNT}회/시간). 인프라 이슈 가능성이 있습니다. 수동 확인이 필요합니다.\n Sentry: ${{ inputs.sentry_url }}\"
+                  \"text\": \"\u26a0\ufe0f [${{ github.repository }}] Sentry Autofix rate limit \ucd08\uacfc (${RECENT_COUNT}\ud68c/\uc2dc\uac04). \uc778\ud504\ub77c \uc774\uc288 \uac00\ub2a5\uc131\uc774 \uc788\uc2b5\ub2c8\ub2e4. \uc218\ub3d9 \ud655\uc778\uc774 \ud544\uc694\ud569\ub2c8\ub2e4.\\n Sentry: ${{ inputs.sentry_url }}\"
                 }"
             fi
           else
@@ -105,6 +109,7 @@ jobs:
           linear_api_key: ${{ secrets.linear_api_key }}
           slack_bot_token: ${{ secrets.slack_bot_token }}
           slack_channel_id: ${{ inputs.slack_channel_id }}
+          slack_mention_user_id: ${{ inputs.slack_mention_user_id }}
           model: ${{ inputs.model }}
           sentry_issue_id: ${{ inputs.sentry_issue_id }}
           sentry_url: ${{ inputs.sentry_url }}

--- a/sentry-autofix/action.yml
+++ b/sentry-autofix/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Slack channel ID for autofix notifications'
     required: false
     default: ''
+  slack_mention_user_id:
+    description: 'Slack user ID to mention in notifications (e.g. U02J2GLUCHY)'
+    required: false
+    default: ''
   model:
     description: 'Claude model to use'
     required: false
@@ -136,8 +140,15 @@ runs:
       env:
         SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
         SLACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
+        SLACK_MENTION_USER_ID: ${{ inputs.slack_mention_user_id }}
         GH_TOKEN: ${{ github.token }}
       run: |
+        # Build optional mention text
+        MENTION_TEXT=""
+        if [ -n "$SLACK_MENTION_USER_ID" ]; then
+          MENTION_TEXT=" <@${SLACK_MENTION_USER_ID}>"
+        fi
+
         # Check for PR first, then GitHub Issue
         PR_INFO=$(gh pr list --repo ${{ github.repository }} --state open --json number,url,title --jq '.[0] // empty')
         PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
@@ -150,7 +161,7 @@ runs:
             -H "Content-Type: application/json" \
             -d "{
               \"channel\": \"$SLACK_CHANNEL_ID\",
-              \"text\": \"🔧 [${{ github.event.repository.name }}] AI Autofix PR이 생성되었습니다.\n<$PR_URL|$PR_TITLE>\",
+              \"text\": \"\ud83d\udd27 [${{ github.event.repository.name }}] AI Autofix PR\uc774 \uc0dd\uc131\ub418\uc5c8\uc2b5\ub2c8\ub2e4.${MENTION_TEXT}\\n<$PR_URL|$PR_TITLE>\",
               \"unfurl_links\": false
             }")
 
@@ -174,7 +185,7 @@ runs:
             -H "Content-Type: application/json" \
             -d "{
               \"channel\": \"$SLACK_CHANNEL_ID\",
-              \"text\": \"📋 [${{ github.event.repository.name }}] AI Autofix가 코드 수정 대신 GitHub Issue를 생성했습니다.\n<$ISSUE_URL|$ISSUE_TITLE>\",
+              \"text\": \"\ud83d\udccb [${{ github.event.repository.name }}] AI Autofix\uac00 \ucf54\ub4dc \uc218\uc815 \ub300\uc2e0 GitHub Issue\ub97c \uc0dd\uc131\ud588\uc2b5\ub2c8\ub2e4.${MENTION_TEXT}\\n<$ISSUE_URL|$ISSUE_TITLE>\",
               \"unfurl_links\": false
             }"
         fi


### PR DESCRIPTION
## Summary
- `sentry-autofix` 액션과 재사용 워크플로우에 `slack_mention_user_id` 입력 추가
- PR/Issue 생성 시 Slack 알림에 지정한 유저를 멘션 (`<@USER_ID>` 형식)
- 입력값이 없으면 기존과 동일하게 멘션 없이 전송 (backward compatible)