### PR TITLE
sentry-autofix: run full pre-commit gate before commit (not just ruff format)

### DIFF
--- a/sentry-autofix/action.yml
+++ b/sentry-autofix/action.yml
@@ -86,7 +86,16 @@ runs:
              - Title: the Sentry error title
              - Project: choose the most relevant project by listing existing projects. If unsure, use "Backend Bugs"
           6. Read the relevant source files and fix the bug
-          7. Run `ruff format` on all modified files to ensure code style compliance
+          7. Run the project's FULL pre-commit gate exactly as CI runs it — this is
+             the same `pre-commit` check the PR's CI will enforce, so it must pass
+             locally before you commit. Find the command in CLAUDE.md /
+             .pre-commit-config.yaml / the CI workflow (commonly
+             `uv run pre-commit run --all-files`, or `pre-commit run --all-files`).
+             This runs BOTH the linter incl. import sorting (`ruff check`, rule I001)
+             AND the formatter (`ruff format`). Running `ruff format` alone is NOT
+             enough — it does not fix import order/lint issues and the CI `pre-commit`
+             job will fail. Fix every issue reported and re-run until all hooks pass;
+             if a hook auto-modifies files, stage those changes too.
           8. Run tests to verify the fix doesn't break anything
           9. Create a new branch using the Linear issue's branch name
           10. Commit the fix with message: "[DRT-<number>] <description>"
@@ -99,7 +108,8 @@ runs:
           Important:
           - Follow the project conventions in CLAUDE.md
           - Write minimal, focused fixes - don't refactor unrelated code
-          - Run `ruff format` on modified files before committing
+          - The full pre-commit gate (see step 7) MUST pass before you commit and open
+            the PR — never commit while any hook is failing
           - If you cannot determine the fix confidently, create a GitHub Issue explaining why instead of creating a PR
           - Always respond in Korean when commenting on issues or PRs
 


### PR DESCRIPTION
## 문제

Sentry Autofix가 만든 PR은 **CI의 `pre-commit` job이 거의 항상 깨집니다.**

원인은 `sentry-autofix/action.yml`의 프롬프트가 커밋 전에 **`ruff format`만** 실행하도록 지시하기 때문입니다:
- `ruff format` = 포매팅만. import 정렬(`ruff check`, 규칙 `I001`)이나 나머지 pre-commit 훅은 안 돎.
- 그래서 import 순서 같은 lint 이슈가 그대로 커밋되어 CI `pre-commit` 게이트에서 fail.

실제 사례: mochii-server [#370](https://github.com/drtail/mochii-server/pull/370) — autofix가 `from ...client import DrtailClient, _OAUTH_TIMEOUT` 로 커밋 → ruff `I001` 위반 → CI pre-commit fail.

## 변경

프롬프트만 수정 (동작/도구 변경 없음):
- **Step 7**: `ruff format` 단독 → **프로젝트의 전체 pre-commit 게이트를 CI와 동일하게 실행**하고 통과시킨 뒤 커밋하도록 지시 (`uv run pre-commit run --all-files` / `pre-commit run --all-files`). lint+import-sort+format 모두 포함됨을 명시.
- **Important** 섹션: `ruff format` 문구 → pre-commit 게이트 통과가 커밋 전제조건임을 명시.

`--allowedTools`에는 이미 bare `Bash`가 있어 pre-commit 실행 권한은 충분합니다. 프롬프트만 바꾸면 됩니다.

## 영향 범위

이 action을 쓰는 **모든 레포(mochii-server, drtail-server2 등)의 autofix PR**에 적용됩니다. 각 레포의 pre-commit 설정을 그대로 따르도록 repo-agnostic하게 작성했습니다.

## 검증

- YAML 파싱 OK.
- 실제 동작 검증은 Sentry 이벤트 트리거가 필요해 머지 후 다음 autofix PR에서 확인 가능 (프롬프트 텍스트 변경뿐이라 리스크 낮음).