### PR TITLE
pr-label: bump setup-node to v22 (fix node:sqlite crash)

### DIFF
--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: corepack enable pnpm
       - run: cd pr-label && pnpm install
       - run: cd pr-label && pnpm build


### PR DESCRIPTION
## 문제

`PR Labeler` 워크플로우(`.github/workflows/pr-label.yaml`)가 **모든 PR에서 fail**합니다.

`setup-node`가 `node-version: 20`을 깔지만, `corepack`의 pnpm(11.2.2)은 **Node ≥22.13** + `node:sqlite` 빌트인(Node 22.5+)을 요구합니다. Node 20에선 `pnpm install` 단계에서 크래시:

```
warn: This version of pnpm requires at least Node.js v22.13. The current version of Node.js is v20.20.2
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

(예: drtail/actions#32 의 pr-label 체크 fail)

## 변경

`node-version: 20 → 22` (1줄). pnpm 요구사항 충족 + `node:sqlite` 사용 가능.

## 참고

이 워크플로우는 `on: pull_request`라 PR 실행 시 **base(main)의 YAML**을 사용합니다. 따라서 이 PR 자신의 pr-label 체크는 머지 전까지 빨간색이며, **main 머지 후 다른 PR(및 재실행)부터 green**이 됩니다. pr-label은 비필수(UNSTABLE) 체크라 머지에는 지장 없습니다.