### PR TITLE
sentry-autofix: notify only about the PR/issue this run created

### DIFF
--- a/sentry-autofix/action.yml
+++ b/sentry-autofix/action.yml
@@ -60,6 +60,24 @@ runs:
       with:
         fetch-depth: 0
 
+    # autofix 실행 "전" 시점의 열린 PR/이슈 번호를 스냅샷한다.
+    # Notify 단계에서 이번 run 이 새로 생성한 PR/이슈만 정확히 식별하기 위함.
+    - name: Snapshot open PRs and issues
+      if: inputs.slack_bot_token != '' && inputs.slack_channel_id != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+      run: |
+        gh pr list --repo "$REPO" --state open --limit 100 \
+          --json number --jq '[.[].number]' \
+          > "$RUNNER_TEMP/autofix_prs_before.json" \
+          || echo '[]' > "$RUNNER_TEMP/autofix_prs_before.json"
+        gh issue list --repo "$REPO" --state open --limit 100 \
+          --json number --jq '[.[].number]' \
+          > "$RUNNER_TEMP/autofix_issues_before.json" \
+          || echo '[]' > "$RUNNER_TEMP/autofix_issues_before.json"
+
     - name: Run Claude Code Autofix
       uses: anthropics/claude-code-action@v1
       with:
@@ -152,50 +170,95 @@ runs:
         SLACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
         SLACK_MENTION_USER_ID: ${{ inputs.slack_mention_user_id }}
         GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
-        # Build optional mention text
+        # 멘션 텍스트 (옵션)
         MENTION_TEXT=""
         if [ -n "$SLACK_MENTION_USER_ID" ]; then
           MENTION_TEXT=" <@${SLACK_MENTION_USER_ID}>"
         fi
 
-        # Check for PR first, then GitHub Issue
-        PR_INFO=$(gh pr list --repo ${{ github.repository }} --state open --json number,url,title --jq '.[0] // empty')
+        # Slack 전송 헬퍼 — payload 를 jq 로 생성해 UTF-8/이스케이프를 안전하게 처리한다.
+        post_slack() {
+          jq -n --arg channel "$SLACK_CHANNEL_ID" --arg text "$1" \
+            '{channel: $channel, text: $text, unfurl_links: false}' \
+            | curl -s -X POST "https://slack.com/api/chat.postMessage" \
+                -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+                -H "Content-Type: application/json" \
+                --data @-
+        }
+
+        BEFORE_PRS="$RUNNER_TEMP/autofix_prs_before.json"
+        BEFORE_ISSUES="$RUNNER_TEMP/autofix_issues_before.json"
+        [ -f "$BEFORE_PRS" ] || echo '[]' > "$BEFORE_PRS"
+        [ -f "$BEFORE_ISSUES" ] || echo '[]' > "$BEFORE_ISSUES"
+
+        # 이번 run 이 "새로 생성한" PR 만 식별한다.
+        # (기존 버그: 레포의 최신 열린 PR `.[0]` 을 집어 무관한 draft PR 을 autofix PR 로 오인 발송)
+        # 규칙: 스냅샷 이후 새로 열린 PR → draft 제외 → 🤖 AI Review 라벨 우선 → 최신(createdAt).
+        gh pr list --repo "$REPO" --state open --limit 100 \
+          --json number,url,title,createdAt,isDraft,labels \
+          > "$RUNNER_TEMP/autofix_prs_after.json" \
+          || echo '[]' > "$RUNNER_TEMP/autofix_prs_after.json"
+
+        PR_INFO=$(jq -n \
+          --slurpfile before "$BEFORE_PRS" \
+          --slurpfile after "$RUNNER_TEMP/autofix_prs_after.json" '
+            ($before[0] // []) as $b
+            | ($after[0] // [])
+            | map(select((.number) as $n | ($b | index($n)) | not))
+            | map(select(.isDraft | not))
+            | (map(select(.labels | any(.name == "🤖 AI Review")))) as $labeled
+            | (if ($labeled | length) > 0 then $labeled else . end)
+            | sort_by(.createdAt) | last // empty
+          ')
         PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
         PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty')
         PR_TITLE=$(echo "$PR_INFO" | jq -r '.title // empty')
 
         if [ -n "$PR_URL" ]; then
-          RESPONSE=$(curl -s -X POST "https://slack.com/api/chat.postMessage" \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"$SLACK_CHANNEL_ID\",
-              \"text\": \"\ud83d\udd27 [${{ github.event.repository.name }}] AI Autofix PR\uc774 \uc0dd\uc131\ub418\uc5c8\uc2b5\ub2c8\ub2e4.${MENTION_TEXT}\\n<$PR_URL|$PR_TITLE>\",
-              \"unfurl_links\": false
-            }")
+          TEXT=$(printf '🔧 [%s] AI Autofix PR이 생성되었습니다.%s\n<%s|%s>' \
+            "$REPO_NAME" "$MENTION_TEXT" "$PR_URL" "$PR_TITLE")
+          RESPONSE=$(post_slack "$TEXT")
 
           SLACK_TS=$(echo "$RESPONSE" | jq -r '.ts // empty')
           SLACK_CHANNEL=$(echo "$RESPONSE" | jq -r '.channel // empty')
 
           if [ -n "$SLACK_TS" ] && [ -n "$PR_NUMBER" ]; then
-            gh pr comment "$PR_NUMBER" --repo ${{ github.repository }} \
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
               --body "<!-- slack:${SLACK_CHANNEL}:${SLACK_TS} -->"
           fi
           exit 0
         fi
 
-        # Check for recently created GitHub Issue
-        ISSUE_URL=$(gh issue list --repo ${{ github.repository }} --state open --limit 1 --json url,title --jq '.[0].url // empty')
-        ISSUE_TITLE=$(gh issue list --repo ${{ github.repository }} --state open --limit 1 --json url,title --jq '.[0].title // empty')
+        # PR 이 없으면, 이번 run 이 새로 생성한 GitHub Issue 를 동일한 스냅샷 diff 로 식별.
+        gh issue list --repo "$REPO" --state open --limit 100 \
+          --json number,url,title,createdAt \
+          > "$RUNNER_TEMP/autofix_issues_after.json" \
+          || echo '[]' > "$RUNNER_TEMP/autofix_issues_after.json"
+
+        ISSUE_INFO=$(jq -n \
+          --slurpfile before "$BEFORE_ISSUES" \
+          --slurpfile after "$RUNNER_TEMP/autofix_issues_after.json" '
+            ($before[0] // []) as $b
+            | ($after[0] // [])
+            | map(select((.number) as $n | ($b | index($n)) | not))
+            | sort_by(.createdAt) | last // empty
+          ')
+        ISSUE_URL=$(echo "$ISSUE_INFO" | jq -r '.url // empty')
+        ISSUE_TITLE=$(echo "$ISSUE_INFO" | jq -r '.title // empty')
 
         if [ -n "$ISSUE_URL" ]; then
-          curl -s -X POST "https://slack.com/api/chat.postMessage" \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"$SLACK_CHANNEL_ID\",
-              \"text\": \"\ud83d\udccb [${{ github.event.repository.name }}] AI Autofix\uac00 \ucf54\ub4dc \uc218\uc815 \ub300\uc2e0 GitHub Issue\ub97c \uc0dd\uc131\ud588\uc2b5\ub2c8\ub2e4.${MENTION_TEXT}\\n<$ISSUE_URL|$ISSUE_TITLE>\",
-              \"unfurl_links\": false
-            }"
+          TEXT=$(printf '📋 [%s] AI Autofix가 코드 수정 대신 GitHub Issue를 생성했습니다.%s\n<%s|%s>' \
+            "$REPO_NAME" "$MENTION_TEXT" "$ISSUE_URL" "$ISSUE_TITLE")
+          post_slack "$TEXT" > /dev/null
+          exit 0
         fi
+
+        # 새로 만든 PR/이슈가 전혀 없음 = autofix 가 결과물을 못 냄(크레딧 소진/판단 보류 등).
+        # 기존엔 이 경우 무관한 최신 PR 을 오인 발송했다. 이제는 결과 없음을 알리고 run 로그를 가리킨다.
+        TEXT=$(printf '⚠️ [%s] AI Autofix가 수정안(PR/Issue)을 생성하지 못했습니다. 런 로그를 확인해주세요.%s\n<%s|실행 로그 보기>' \
+          "$REPO_NAME" "$MENTION_TEXT" "$RUN_URL")
+        post_slack "$TEXT" > /dev/null


### PR DESCRIPTION
## Summary

`sentry-autofix` 액션의 **Notify Slack** 단계가 이번 run 이 만든 PR 을 식별하지 않고
`gh pr list --state open --jq '.[0]'`(= 레포의 최신 열린 PR)을 집어 알림을 보내고 있었다.

→ autofix 의 `claude-code-action` 이 결과물을 못 만든 경우(예: **Anthropic 크레딧 소진**,
판단 보류, 무변경) 레포의 최신 열린 PR(무관한 팀원 draft PR 등)을
"🔧 AI Autofix PR 이 생성되었습니다"로 **오인 발송**한다.

평소엔 "방금 만든 PR == 최신 PR"이라 우연히 맞아떨어져 드러나지 않다가,
2026-06-28 크레딧 소진 사고 때 autofix 가 PR 을 못 만드는 동안
같은 draft PR 을 반복 오인 발송하며 드러났다.

## Root cause

```bash
# 기존 — 레포의 아무 최신 열린 PR 이나 집어옴
PR_INFO=$(gh pr list --repo ... --state open --json number,url,title --jq '.[0] // empty')
```
- 이 run 이 PR 을 만들었는지 여부와 무관하게 항상 `.[0]` 을 가져옴
- `if: success()` 인데 `claude-code-action` 은 크레딧 400 에러에도 exit 0 → notify 가 그대로 실행
- GitHub Issue 분기도 동일하게 `gh issue list .[0]` 로 무관한 이슈를 집을 수 있었음

## Changes

- **새 스텝 `Snapshot open PRs and issues`** (Claude 실행 *전*): 열린 PR/이슈 번호를 `$RUNNER_TEMP` 에 스냅샷
- **Notify 재작성**: 스냅샷 이후 *새로 생성된* PR/이슈만 식별
  - PR: 새로 생긴 것 → `draft` 제외 → `🤖 AI Review` 라벨 우선 → 최신 `createdAt`
  - Issue: 새로 생긴 것 → 최신 `createdAt`
- **결과물이 없으면** 무관한 PR 을 가리키지 않고 `⚠️ 수정안(PR/Issue)을 생성하지 못함 + 실행 로그` 알림
- Slack payload 를 `jq` 로 생성 → PR 제목에 `"` 등이 있어도 안전(기존 hand-escaped JSON 은 깨짐)

## Behavior (before → after)

| 상황 | before | after |
|---|---|---|
| autofix PR 생성됨 | 보통 맞음(운) | 이 run 이 만든 PR 정확히 발송 |
| autofix 가 결과물 못 냄(크레딧 등) | **무관한 최신 PR 오인 발송** | "생성 못함 + run 로그" 발송 |
| 동시간 사람 PR 존재 | 사람 PR 오인 가능 | 라벨/스냅샷으로 autofix PR 우선 |

## Validation

- `ruby -ryaml` 파싱 OK (steps: Checkout / Snapshot / Run Claude / Notify)
- 두 `run` 블록 `bash -n` OK
- jq 식별 로직 시나리오 7종 통과(크레딧실패=무발송 / 새PR선택 / 라벨우선 / 라벨누락 fallback / draft제외 / 새이슈선택 / 빈입력 가드)
- jq payload 빌더: 따옴표·이모지·개행·백슬래시 포함해도 유효 JSON 생성 확인

## ⚠️ Blast radius

이 액션은 사용처에서 `@main` 으로 참조됨 → **머지 즉시 전 레포에 적용**됩니다.
리뷰 후 머지 부탁드립니다. (CI 자동 트리거 아님 — 다음 Sentry dispatch 때 적용)

## References

- 관련 사고: 2026-06-28 Anthropic 크레딧 소진 (chat `conversation_mode_detection_failed` 13명, proactive `selector_llm_failed` 등) → 충전으로 복구
- 이전 같은 액션 수정: #32 (pre-commit gate)
