### PR TITLE
docs: AI-review 주석/문서에서 3->2/2->1 표기 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ passed through as inputs; a missing/unscoped token simply skips that source (nev
 review). A link that can't be read (Slack bot not in channel, Notion page not shared, …) is
 reported under "수집 실패" in `.pr-context.md` so the reviewer never guesses.
 
-### 4a. claude-django-review-loop — small PR (`3 -> 2`, base ≠ trunk)
+### 4a. claude-django-review-loop — small PR (base ≠ trunk)
 
 Review-reflect-re-review loop (min 2, max 5 rounds). Verifies the PR's Acceptance Criteria are
 implemented **exactly — no more, no less** against the diff and the linked Linear issue, plus
@@ -135,7 +135,7 @@ jobs:
           allowed_bots: 'claude'
 ```
 
-### 4b. claude-parent-review — big PR (`2 -> 1`, base = trunk)
+### 4b. claude-parent-review — big PR (base = trunk)
 
 Completeness audit of a platform integration PR against its **Linear parent issue**: checks
 that the PR delivers exactly the backend-relevant scope (기술 목표 / 작업 내용 / 영향 범위 /

--- a/claude-parent-review/action.yml
+++ b/claude-parent-review/action.yml
@@ -3,7 +3,7 @@ description: 'Completeness review of a platform integration PR against its Linea
 author: 'drtail'
 
 # Big PR = a platform (backend) integration PR merging into the trunk branch, i.e. the
-# "2 -> 1" PR that rolls a platform's work up to the parent. Unlike the small-PR review
+# integration PR that rolls a platform's work up to the parent. Unlike the small-PR review
 # this audits COMPLETENESS: does this single PR deliver exactly the backend-relevant
 # scope of the Linear parent issue — no more, no less. It intentionally does NOT emit the
 # "AI Review APPROVED" marker, so it never triggers reviewer auto-assignment; the human


### PR DESCRIPTION
머지된 파일들의 3->2/2->1 표기 제거 (base==/!=trunk 문구는 유지). AI Review 워크플로 개편 후속 정리.