### PR TITLE
parent-review: allow read-only git in agent allowlist

### DIFF
--- a/claude-parent-review/action.yml
+++ b/claude-parent-review/action.yml
@@ -158,7 +158,18 @@ runs:
           IMPORTANT: Never write files to /tmp/ or outside the repository root.
           Save your ${{ inputs.review_language }} review to '.claude-parent-review.md' using the Write tool. Do NOT post to the PR yourself.
 
-        claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Write,Read,Glob,Grep"'
+          NOTE: The repository is checked out with FULL history (fetch-depth 0) — all
+          branches are already available as origin/* refs. For a big integration diff,
+          prefer local read-only git over `gh pr diff`: e.g.
+          `git diff origin/<base>...origin/<head>` (aggregate), `git log`, and
+          `git show <sha>` (per-commit). No `git fetch` is needed. Avoid piping through
+          other commands (tail/head/etc.) — pipes may be blocked by the tool allowlist;
+          plain output is truncated safely by the harness.
+
+        # Bash 허용 목록: gh pr 조회 + read-only git 조사 명령.
+        # 큰 PR(수천 라인 diff)은 에이전트가 커밋 단위 분석(git show/diff)을 필요로 하는데,
+        # git 이 전부 차단되면 리뷰 파일을 못 쓰고 종료한다(mochii-server#564 R1 실패 사례).
+        claude_args: '--model claude-sonnet-5 --allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Write,Read,Glob,Grep"'
 
     - name: Post review to PR
       uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

큰 PR 완결성 리뷰(claude-parent-review)가 mochii-server#564(5.8k 라인, 7커밋 통합 PR)에서 실패한 원인 수정.

에이전트가 커밋 단위 분석을 위해 `git diff <sha>^..<sha>` / `git show` 등을 수십 회 시도했으나 allowlist(`gh pr diff/view/list`만 허용)에 전부 차단 → 리뷰 파일(`.claude-parent-review.md`) 미작성 → post 단계 ENOENT 실패.

## Changes

- `--allowed-tools`에 read-only git 추가: `git diff` / `git log` / `git show` / `git branch`
  - `git fetch`는 **미허용 유지** — checkout이 fetch-depth 0이라 모든 origin/* refs가 이미 로컬에 있음
- 프롬프트에 full-history 체크아웃 안내 + 파이프(tail/head) 회피 힌트 추가 — 불필요한 fetch/파이프 시도로 인한 거부 flail 방지

## Notes

- 작은 PR 액션(claude-django-review-loop)은 동일 allowlist지만 diff가 작아(≤700줄) `gh pr diff`+Read로 충분 — 14/14 성공. 필요 시 후속에서 동일 적용 가능.
- 검증: YAML 파싱 OK. 머지 후 mochii-server#564에 라벨 재부착으로 재실행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkDtvytSeRtj5sn6obajY3